### PR TITLE
Add option to save UrQMD particle data to hdf5 file

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,9 @@ The basic usage is
 
     run-events [options] results_file
 
-Observables are written to `results_file` in __binary__ format (see [event data format](#event-data-format) below).
+Observables are written to `results_file` in __binary__ format.
+Raw particle data may also be saved to an hdf5 file using the option `--particles <filename>`.
+For more information, see [event data format](#event-data-format) and [raw particle data](#raw-particle-data) below.
 
 The most common options are:
 
@@ -108,6 +110,26 @@ The metadata takes up too much space relative to the actual data and reading man
 
 The best solution would probably be some kind of scalable database (perhaps MongoDB), but I simply haven't had time to get that up and running.
 If someone wants to do it, by all means go ahead!
+
+### Raw particle data
+
+Occasionally, it is necessary to save the UrQMD particle data output by each event. This can produce _a lot_ of data, typically on the order of ~1 MB per event.
+
+The raw particle data may be saved to an hdf5 file using `--particles <filename>`. The hdf5 file is easily loaded and inspected in Python. For example,
+```python
+import h5py
+
+with h5py.File('particles.hdf', 'r') as f:
+    for event in f.values():
+        for particle in event:
+            print(particle.dtype)
+```
+prints the data format
+```python
+[('sample', '<i8'), ('ID', '<i8'), ('charge', '<i8'), ('pT', '<f8'), ('ET', '<f8'), ('mT', '<f8'), ('phi', '<f8'), ('y', '<f8'), ('eta', '<f8')]
+```
+for each particle in the event. Here `sample` denotes the number of the UrQMD oversample, `ID` is the Particle Data Group particle number, `charge` is its electric charge, `pT` the transverse momentum, `ET` the transverse energy, `mT` the transverse mass, `phi` the azimuthal angle, `y` the rapidity, and `eta` the pseudorapidity.
+
 
 ### Input files
 

--- a/models/run-events
+++ b/models/run-events
@@ -1,8 +1,9 @@
 #!/usr/bin/env python3
 
 import argparse
+from contextlib import contextmanager
 import datetime
-from itertools import chain, repeat
+from itertools import chain, groupby, repeat
 import logging
 import math
 import os
@@ -163,6 +164,10 @@ parser.add_argument(
     help='checkpoint file [pickle format]'
 )
 parser.add_argument(
+    '--particles', type=os.path.abspath, metavar='PATH',
+    help='raw particle data file (default: do not save)'
+)
+parser.add_argument(
     '--logfile', type=os.path.abspath, metavar='PATH',
     help='log file (default: stdout)'
 )
@@ -197,7 +202,7 @@ class StopEvent(Exception):
     """ Raise to end an event early. """
 
 
-def run_events(args, results_file, checkpoint_ic=None):
+def run_events(args, results_file, particles_file=None, checkpoint_ic=None):
     """
     Run events as determined by user input:
 
@@ -389,7 +394,20 @@ def run_events(args, results_file, checkpoint_ic=None):
         ('flow', [('N', int_t), ('Qn', complex_t, 8)]),
     ])
 
-    def run_single_event(ic):
+    # UrQMD raw particle format
+    parts_dtype = [
+        ('sample', int),
+        ('ID', int),
+        ('charge', int),
+        ('pT', float),
+        ('ET', float),
+        ('mT', float),
+        ('phi', float),
+        ('y', float),
+        ('eta', float)
+    ]
+
+    def run_single_event(ic, event_number):
         """
         Run the initial condition event contained in HDF5 dataset object `ic`
         and save observables to `results`.
@@ -452,18 +470,29 @@ def run_events(args, results_file, checkpoint_ic=None):
 
         # read final particle data
         with open('particles_out.dat', 'rb') as f:
-            parts = np.fromiter(
-                (tuple(l.split()) for l in f if not l.startswith(b'#')),
-                dtype=[
-                    ('ID', int),
-                    ('charge', int),
-                    ('pT', float),
-                    ('ET', float),
-                    ('mT', float),
-                    ('phi', float),
-                    ('y', float),
-                    ('eta', float),
-                ]
+
+            # partition UrQMD file into oversamples
+            groups = groupby(f, key=lambda l: l.startswith(b'#'))
+            samples = filter(lambda g: not g[0], groups)
+
+            # iterate over particles and oversamples
+            parts_iter = (
+                tuple((nsample, *l.split()))
+                for nsample, (header, sample) in enumerate(samples, start=1)
+                for l in sample
+            )
+
+            parts = np.fromiter(parts_iter, dtype=parts_dtype)
+
+        # save raw particle data (optional)
+        if particles_file is not None:
+
+            # save event to hdf5 data set
+            logging.info('saving raw particle data')
+
+            particles_file.create_dataset(
+                'event_{}'.format(event_number),
+                data=parts, compression='lzf'
             )
 
         logging.info('computing observables')
@@ -508,8 +537,11 @@ def run_events(args, results_file, checkpoint_ic=None):
         logging.info('starting event %d', n)
 
         try:
-            run_single_event(ic)
+            run_single_event(ic, n)
         except StopEvent as e:
+            particles_file.create_dataset(
+                'event_{}'.format(n), shape=(0,), dtype=parts_dtype
+            )
             logging.info('event stopped: %s', e)
         except Exception:
             logging.exception('event %d failed', n)
@@ -556,7 +588,7 @@ def main():
 
             # append rank to path arguments, e.g.:
             #   /path/to/output.log  ->  /path/to/output/<rank>.log
-            for a in ['results', 'logfile', 'checkpoint']:
+            for a in ['results', 'logfile', 'particles', 'checkpoint']:
                 value = getattr(args, a)
                 if value is not None:
                     root, ext = os.path.splitext(value)
@@ -572,6 +604,9 @@ def main():
     else:
         logfile_kwargs = dict(filename=args.logfile, filemode=filemode)
         os.makedirs(os.path.dirname(args.logfile), exist_ok=True)
+
+    if args.particles is not None:
+        os.makedirs(os.path.dirname(args.particles), exist_ok=True)
 
     if args.checkpoint is not None:
         os.makedirs(os.path.dirname(args.checkpoint), exist_ok=True)
@@ -597,16 +632,21 @@ def main():
     signal.signal(signal.SIGTERM, signal.default_int_handler)
     logging.debug('set SIGTERM handler')
 
+    @contextmanager
+    def h5py_file():
+        yield h5py.File(args.particles, 'w') if args.particles else None
+
     with \
             open(args.results, filemode + 'b',
                  buffering=args.buffering) as results_file, \
+            h5py_file() as particles_file, \
             tempfile.TemporaryDirectory(
                 prefix='hic-', dir=args.tmpdir) as workdir:
         os.chdir(workdir)
         logging.info('working directory: %s', workdir)
 
         try:
-            status = run_events(args, results_file, checkpoint_ic)
+            status = run_events(args, results_file, particles_file, checkpoint_ic)
         except KeyboardInterrupt:
             # after catching the initial SIGTERM or interrupt, ignore them
             # during shutdown -- this ensures everything will exit gracefully


### PR DESCRIPTION
Add the runtime option `--particles <filename>` to save UrQMD output to an hdf5 file. Does not save the raw particle information by default.